### PR TITLE
chore(build): drop `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include kfac_jax/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,3 +73,7 @@ tests = [
   "dm-tree>=0.1.7",
   "optax>=0.1.4",
 ]
+
+[tool.setuptools.packages.find]
+include=["kfac_jax/py.typed"]
+


### PR DESCRIPTION
Builds on top of work done in #208.

Drops `MANIFEST.in` by using the `find` directive in `pyproject.toml`. [docs reference](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html)

Request for Review: @fabianp 