### PR TITLE
chore(build): drop `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include kfac_jax/py.typed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,6 @@ tests = [  # these should be version pinned?
   "dm-tree>=0.1.7",
   "optax>=0.1.4",
 ]
+
+[tool.setuptools.package-data]
+"*" = ["py.typed"]


### PR DESCRIPTION
This PR drops the `MANIFEST.in` file in favour of `tool.setuptools.package-data` in `pyproject.toml`.

I verified the changes by building the package and asserting `py.typed` is in the distribution:

```bash
> python -m build
> tar -tzf dist/kfac_jax-0.0.6.tar.gz | grep "py.typed"

kfac_jax-0.0.6/kfac_jax/py.typed
```

Request for Review: @fabianp 