### PR TITLE
Fix LayerTag docstring: remove misleading 'with the given name'

### DIFF
--- a/kfac_jax/_src/layers_and_loss_tags.py
+++ b/kfac_jax/_src/layers_and_loss_tags.py
@@ -272,7 +272,7 @@ class LayerTag(jex.core.Primitive):
   """
 
   def __init__(self):
-    """Initializes a layer tag primitive with the given name.
+    """Initializes a layer tag primitive.
 
     Any layer tag primitive must have the following interface `layer_tag(
     *outputs, *inputs, *parameters, **kwargs)`. We refer collectively to


### PR DESCRIPTION
Fixes #401

The `__init__` docstring for `LayerTag` said it initializes a primitive
"with the given name", implying a `name` parameter. The constructor takes
no arguments and hardcodes the name to `"layer_tag"`.

This caused confusion for users who tried to pass a name argument (e.g.,
`LayerTag("my_tag")`).